### PR TITLE
[minor] duration flag can accept additional string values

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,23 +22,27 @@ Available options:
 * Binaries for all platforms (macOS, Linux, *BSD) on [GitHub Releases](https://github.com/joemiller/certin/releases)
 * [Docker images](https://hub.docker.com/r/joemiller/certin)
 
-Examples:
+Usage:
 
 ```console
-$ certin create KEY CERT \
-    [--bundle=tls.pem] \         # (optional) Create combined bundle FILE containing private-key, certificate, and signing CA cert
-    [--signer-key=CA.key] \      # if not set, CERT will be self-signed
-    [--signer-cert=CA.crt] \     # ""
-    [--cn=COMMON-NAME] \
-    [--o=ORG] \
-    [--ou=ORG-UNIT] \
-    [--duration=8760h]           # certificate duration (TTL, expiration). default 1yr
-    [--is-ca=false]              # create a new CA (cert will have CA:TRUE). If --signer-key/cert is set this will be an intermediate cert
-    [--sans=SANS]                # comma-separated list of SubjectAltNames. DNS, IP, Email, URL, and URI supported
-    [--key-type=rsa-2048]        # type and size of KEY to create
+$ certin create KEY CERT
+Flags:
+      --bundle string        (optional) Create combined bundle FILE containing private-key, certificate, and signing CA cert
+      --cn string            common name
+  -d, --duration string      certificate duration. Examples of valid values: 1w, 1d, 2d3h5m, 1h30m, 10s (default "1y")
+  -h, --help                 help for create
+      --is-ca                create a CA cert capable of signing other certs
+  -K, --key-type string      key type to create (rsa-2048, rsa-3072, rsa-4096, ecdsa-256, ecdsa-384, ecdsa-512, ed25519) (default "rsa-2048")
+      --o strings            organization
+      --ou strings           organizational unit
+      --sans strings         SubjectAltNames, comma separated
+  -c, --signer-cert string   CA cert to sign the CERT with. If omitted, a self-signed cert is generated.
+  -k, --signer-key string    CA key to sign the CERT with. If omitted, a self-signed cert is generated.
 ```
 
-* simple self-signed cert:
+Examples:
+
+* self-signed cert:
 
 ```console
 certin create self-signed.key self-signed.crt
@@ -54,19 +58,19 @@ certin create root.key root.crt --is-ca=true
 
 ```console
 certin create intermediate.key intermediate.crt \
-  --signer-key=root.key \
-  --signer-crt=root.crt \
-  --is-ca=true
+  --signer-key root.key \
+  --signer-crt root.crt \
+  --is-ca
 ```
 
-* leaf cert:
+* leaf cert with SubjectAltNames (SANs):
 
 ```console
 certin create example.key example.crt \
-  --signer-key=intermediate.key \
-  --signer-crt=intermediate.crt \
-  --cn="example.com" \
-  --key-type="ecdsa-256"
+  --signer-key intermediate.key \
+  --signer-crt intermediate.crt \
+  --cn "example.com,www.example.com" \
+  --key-type "ecdsa-256"
 ```
 
 Go Library

--- a/cmd/certin/commands/time.go
+++ b/cmd/certin/commands/time.go
@@ -1,0 +1,68 @@
+package commands
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// ParseDuration from Prometheus that supports days, weeks, months, years, unlike the
+// stdlib time.ParseDuration (because days are not always the same length, but we can get close
+// enough for our purposes in this app.
+// https://github.com/prometheus/common/blob/317b7b125e8fddda956d0c9574e5f03f438ed5bc/model/time.go#L188
+
+// original license:
+//
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var durationRE = regexp.MustCompile("^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$")
+
+// ParseDuration parses a string into a time.Duration, assuming that a year
+// always has 365d, a week always has 7d, and a day always has 24h.
+func ParseDuration(durationStr string) (time.Duration, error) {
+	switch durationStr {
+	case "0":
+		// Allow 0 without a unit.
+		return 0, nil
+	case "":
+		return 0, fmt.Errorf("empty duration string")
+	}
+	matches := durationRE.FindStringSubmatch(durationStr)
+	if matches == nil {
+		return 0, fmt.Errorf("not a valid duration string: %q", durationStr)
+	}
+	var dur time.Duration
+
+	// Parse the match at pos `pos` in the regex and use `mult` to turn that
+	// into ms, then add that value to the total parsed duration.
+	m := func(pos int, mult time.Duration) {
+		if matches[pos] == "" {
+			return
+		}
+		n, _ := strconv.Atoi(matches[pos])
+		d := time.Duration(n) * time.Millisecond
+		dur += d * mult
+	}
+
+	m(2, 1000*60*60*24*365) // y
+	m(4, 1000*60*60*24*7)   // w
+	m(6, 1000*60*60*24)     // d
+	m(8, 1000*60*60)        // h
+	m(10, 1000*60)          // m
+	m(12, 1000)             // s
+	m(14, 1)                // ms
+
+	return dur, nil
+}


### PR DESCRIPTION
Using the ParseDuration from the prometheus project to allow for more
flexibility in valid time.duration values such as `d` (day), `w` (week),
`y` (year) etc.

Also, add short-hand flags for common options like --signer-key (-k) and
--signer-cert (-c)