### PR TITLE
[minor] new conversion helpers

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,10 +28,12 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
         shell: bash # force windows to use git-bash for access to curl
 
-      - name: install goreleaser
+      - name: Install GoReleaser
         # only need to lint goreleaser on one platform:
         if: startsWith(runner.os, 'Linux')
-        run: curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sudo sh -s -- -b /usr/local/bin
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          install-only: true
 
       - run: make lint
         shell: bash
@@ -53,8 +55,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: install goreleaser
-        run: curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sudo sh -s -- -b /usr/local/bin
+      - name: Install GoReleaser
+        if: startsWith(runner.os, 'Linux')
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          install-only: true
+
       - run: make snapshot
 
   release:
@@ -85,8 +91,11 @@ jobs:
             git branch --track master origin/master
           fi
 
-      - name: install goreleaser
-        run: curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sudo sh -s -- -b /usr/local/bin
+      - name: Install GoReleaser
+        if: startsWith(runner.os, 'Linux')
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          install-only: true
 
       - name: run autotag to increment version
         run: |

--- a/cmd/certin/commands/create.go
+++ b/cmd/certin/commands/create.go
@@ -230,7 +230,6 @@ func createKeyAndCSR(cmd *cobra.Command, args []string) error {
 
 	cmd.Printf("Success! Wrote: %s, %s\n", keyOut, csrOut)
 	return nil
-
 }
 
 // fileConcat creates a single file 'out' containing the contents of one or more files concatenated.


### PR DESCRIPTION
A common use case for certificates is with tls clients and servers.
These functions basically always consume a `tls.Config` struct with the
`Certificates` and/or `RootCAs` fields populated.

Add two new methods to the `KeyAndCert` struct to export both types and
make the return signature match the expectations of their relevant
fields in `tls.Config`:

```go
tls.Config{
  Certificates: k.TLSCertificate(), // tls.Certificate
  RootCAs: k.CertPool(),            // *x509.CertPool
}
```