### PR TITLE
change go mod version from 1.14 -> 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,16 @@
 module github.com/joemiller/certin
 
-go 1.14
+go 1.17
 
 require (
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )


### PR DESCRIPTION
Upgrading to >=1.16 allows goreleaser to actually build `darwin/arm64` as expected. ([docs](https://goreleaser.com/deprecations/#builds-for-darwinarm64))

Open question: should we also update the actions test matrix to not run the older versions?